### PR TITLE
add strerror prototype and stub implementation

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -91,4 +91,6 @@ void *memchr(const void *s, int c, size_t n);
 
 size_t strnlen(const char *, size_t);
 
+char *strerror(int errnum);
+
 #endif /* _STRING_H_ */

--- a/lib/string.c
+++ b/lib/string.c
@@ -237,4 +237,12 @@ void *memchr(const void *s, int c, size_t n)
     }
     return (NULL);
 }
+
+char *strerror(int errnum)
+{
+    static char *mesg = "strerror-not-implemented";
+
+    return mesg;
+}
+
 #endif


### PR DESCRIPTION
resolves a missing prototype warning in mirage-xen-ocaml

**note:** requires a corresponding change in mirage-platform
